### PR TITLE
Output formatted HTML in generated RSS feed

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -36,6 +36,9 @@ params:
   showtoc: true
   tocopen: false
 
+  # Includes HTML strings in RSS feed with formatting
+  ShowFullTextinRSS: true
+
   assets:
     # disableHLJS: true # to disable highlight.js
     # disableFingerprinting: true


### PR DESCRIPTION
This enables a feature in our template that outputs valid safe HTML in the `<content:encoded>` block of each item in the RSS feed (the template is `<content:encoded>{{ (printf "<![CDATA[%s]]>" .Content) | safeHTML }}</content:encoded>`).

This will allow us to embed blog posts in the news page on the dashboard better (https://github.com/momentum-mod/website/issues/744).